### PR TITLE
seo: embed JS repo in quiz questions

### DIFF
--- a/questions/how-do-you-get-the-query-string-values-of-the-current-page-in-javascript/en-US.mdx
+++ b/questions/how-do-you-get-the-query-string-values-of-the-current-page-in-javascript/en-US.mdx
@@ -76,3 +76,4 @@ params.forEach((value, key) => {
 
 - [MDN Web Docs: URLSearchParams](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams)
 - [MDN Web Docs: window.location](https://developer.mozilla.org/en-US/docs/Web/API/Window/location)
+- [Top JavaScript Interview Questions - GitHub](https://github.com/greatfrontend/top-javascript-interview-questions)

--- a/questions/how-does-javascript-garbage-collection-work/en-US.mdx
+++ b/questions/how-does-javascript-garbage-collection-work/en-US.mdx
@@ -91,3 +91,4 @@ To avoid leaking memory:
 - [Understanding memory management and garbage collection in JavaScript](https://www.linkedin.com/pulse/understanding-memory-management-garbage-collection-aayush-patniya)
 - [JavaScript memory management: A comprehensive guide to garbage collection in JavaScript](https://www.calibraint.com/blog/garbage-collection-in-javascript)
 - [Garbage collection - javascript.info](https://javascript.info/garbage-collection)
+- [Top JavaScript Interview Questions - GitHub](https://github.com/greatfrontend/top-javascript-interview-questions)

--- a/questions/what-are-some-best-practices-for-handling-sensitive-data-in-javascript/en-US.mdx
+++ b/questions/what-are-some-best-practices-for-handling-sensitive-data-in-javascript/en-US.mdx
@@ -82,3 +82,4 @@ npm audit fix
 - [Express.js Security Best Practices](https://expressjs.com/en/advanced/best-practice-security.html)
 - [JSON Web Tokens (JWT) Introduction](https://jwt.io/introduction/)
 - [express-validator Documentation](https://express-validator.github.io/docs/)
+- [Top JavaScript Interview Questions - GitHub](https://github.com/greatfrontend/top-javascript-interview-questions)

--- a/questions/what-are-the-different-ways-to-make-an-api-call-in-javascript/en-US.mdx
+++ b/questions/what-are-the-different-ways-to-make-an-api-call-in-javascript/en-US.mdx
@@ -79,3 +79,4 @@ $.ajax({
 - [MDN Web Docs: Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)
 - [Axios GitHub Repository](https://github.com/axios/axios)
 - [jQuery AJAX Documentation](https://api.jquery.com/jquery.ajax/)
+- [Top JavaScript Interview Questions - GitHub](https://github.com/greatfrontend/top-javascript-interview-questions)


### PR DESCRIPTION
Marketing team wants to add back links our JS questions repo. 

This PR embed JS repo link into some of our questions which are getting more traffic organically